### PR TITLE
Update campfire.mdx

### DIFF
--- a/packages/docs/pages/networks/testnets/campfire.mdx
+++ b/packages/docs/pages/networks/testnets/campfire.mdx
@@ -18,7 +18,7 @@ The most up-to-date docs on joining Campfire ⛺🔥 can be found [here](https:/
 Currently, Campfire ⛺🔥 docs only detail support for Ubuntu machines. 
 </Callout>
 
-The user will need to have installed the [Stack-Orchestrator](https://github.com/vknowable/stack-orchestrator), which is a general tool for quickly and flexibly launching and managing a software stack in a containerized environment. The docs are found in the [README](https://github.com/vknowable/stack-orchestrator/README.md) of the repo, and the tool can be installed by running the following command:
+The user will need to have installed the [Stack-Orchestrator](https://github.com/vknowable/stack-orchestrator), which is a general tool for quickly and flexibly launching and managing a software stack in a containerized environment. The docs are found in the [README](https://github.com/vknowable/stack-orchestrator/blob/main/README.md) of the repo, and the tool can be installed by running the following command:
 
 ```bash copy
 git clone https://github.com/vknowable/stack-orchestrator.git


### PR DESCRIPTION
Hyperlink to README.md: In the section about installing Stack-Orchestrator, the link to the README is broken. It should be https://github.com/vknowable/stack-orchestrator/blob/main/README.md instead of https://github.com/vknowable/stack-orchestrator/README.md.